### PR TITLE
Fixed: "Your worker called response.clone(), but did not read the body of both clones."

### DIFF
--- a/packages/cosmos/src/client.ts
+++ b/packages/cosmos/src/client.ts
@@ -330,7 +330,7 @@ export class CosmosClient {
     request: Request,
     context?: RetryContext
   ): Promise<Response> {
-    const retryRequest = request.clone();
+    const retryRequest = new Request(request.url, request);
 
     const response = await this.fetch(request);
 


### PR DESCRIPTION
Performing operations on the database was printing this warning on the console while running on CF Workers:

```
Your worker called response.clone(), but did not read the body of both clones. This is wasteful, as it forces the system to buffer the entire response body in memory, rather than streaming it through. This may cause your worker to be unexpectedly terminated for going over the memory limit. If you only meant to copy the response headers and metadata (e.g. in order to be able to modify them), use `new Response(response.body, response)` instead.
```

Looks like it was due to using `request.clone()`. This PR fixes it by creating a new Request object instead